### PR TITLE
Add FractalAI post-quantum x402 proof services + witness extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [FractalAI x402 Proofs](https://fractalai.net.co/.well-known/x402.json) - Post-quantum proof services for AI agents: 7 pay-per-call endpoints on Base (USDC, x402 v2, EIP-3009) covering ML-DSA-65/Dilithium-3 (NIST FIPS 204) signing/verification, AI-decision attestation, and provenance sealing, plus an Algorand mainnet adapter via the GoPlausible facilitator. Every response is verifiable offline (the exact signed message is echoed back). Signatures are resistant to known classical & quantum attacks per NIST FIPS 204 — not "unbreakable".
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)
@@ -107,6 +108,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [ERC-3009 Forwarding](https://github.com/TheGreatAxios/eip3009-forwarder): forwarding contract extending meta-transactions with EIP-721 signatures to any ERC-20 on any network
 - [x402 Extensions Overview](https://docs.x402.org/extensions/overview): official guide to x402 resource server and facilitator extension points
 - [A2A x402 Extension](https://github.com/google-agentic-commerce/a2a-x402): specification, libraries, and examples for adding on-chain x402 payments to Agent-to-Agent services
+- [@fractalai/x402-pqc-witness (NPM)](https://www.npmjs.com/package/@fractalai/x402-pqc-witness) - Native `@x402/core` `ResourceServerExtension` that adds a post-quantum (ML-DSA-65) settlement attestation to a resource server's `enrichSettlementResponse` hook. Self-attest mode (free, seller's own key) or notary mode (paid, independent third-party key) for genuine third-party witnessing. Live notary instance: [`/api/x402/witness`](https://fractalai.net.co/api/x402/witness).
 
 ### Tutorials & Guides
 - [AgentCash - Sell to agents](https://agentcash.dev/docs/sell-to-agents)


### PR DESCRIPTION
### Updated 2026-09-05
This PR has been open since July; the service has grown since the original description and the
original said "Dilithium-2" which was stale even at the time of the last commit (the service
signs with ML-DSA-65/Dilithium-3). Rewrote both the entry and the PR to reflect the current, live
state — no change in scope beyond what's actually running today.

### What
Two additions:

1. **Ecosystem**: FractalAI — 7 pay-per-call proof endpoints on Base (x402 v2, USDC, EIP-3009
   gasless) signing with ML-DSA-65/Dilithium-3 (NIST FIPS 204), plus an Algorand mainnet adapter
   settling via the GoPlausible facilitator. Every response is verifiable offline (exact signed
   message echoed back).
2. **Extensions**: `@fractalai/x402-pqc-witness` — a native `@x402/core` `ResourceServerExtension`
   (built against the real `x402ResourceServer` class, not a mock) that adds a post-quantum
   settlement attestation via `enrichSettlementResponse`. Self-attest mode is free (seller's own
   key, integrity only); notary mode is paid and uses an independent third-party key for genuine
   third-party witnessing. We run a live notary instance ourselves.

### Verified live before updating
- `.well-known/x402.json` → 200
- npm package page + registry (`@fractalai/x402-pqc-witness@0.1.0`) → live, published
- `/api/x402/witness` → responds with a valid 402 challenge

### Honesty note
ML-DSA-65 resists known classical & quantum attacks per NIST FIPS 204 — not "unbreakable". No
usage/traction numbers are claimed; this is a description of the live services and package only.