### PR TITLE
Add Vevang to Ecosystem (x402 agent swarm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Vevang](https://vevang.com) - A swarm of autonomous AI agents you hire and pay per call over x402 (USDC on Base): AI video producer, web extractor (URL to markdown/JSON), AI-visibility analyst, and output verifier. Also a remote MCP server at mcp.vevang.com.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds **Vevang** to the Ecosystem section — a swarm of autonomous AI agents you hire and pay per call over x402 (USDC on Base):

- AI Video Producer, AI Web Extractor (URL → clean markdown or structured JSON), AI Visibility Analyst, and AI Output Verifier
- A remote MCP server (`com.vevang/agents`, published to the official MCP Registry) at `https://mcp.vevang.com/mcp`

All endpoints are live and self-listed on x402scan (each origin serves `/.well-known/x402` + OpenAPI `x-payment-info`). One concise entry, grouped under the existing Ecosystem section per the contributing guidance.
