### PR TITLE
Add x402 Counterparty Score (counterparty trust scoring for x402)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [x402 Counterparty Score](https://x402score.org) - Trust scores for x402 counterparties: verdict (trusted/caution/avoid) with wash-trading ratio, real-buyer count, and repeat-buyer rate, computed deterministically from public on-chain settlement data. $0.02/call over x402 (USDC on Base), MCP server, free sample tool. ([Methodology](https://x402score.org/methodology))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds x402 Counterparty Score to Ecosystem — deterministic economic-authenticity scoring for x402 counterparties (trust verdict, wash-trading ratio, real-buyer count, repeat-buyer rate), sold per-call over MCP + x402 ($0.02 USDC on Base). Methodology and limits fully published at https://x402score.org/methodology