### PR TITLE
Add Aeon under Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Aeon](https://github.com/aeonfun/aeon) - Autonomous agent framework that runs unattended on GitHub Actions; scheduled Markdown skills settle x402 payments in USDC through Bankr agent wallets on Base, alongside Uniswap v4 hook deploys and on-chain monitoring. MIT.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adding **[Aeon](https://github.com/aeonfun/aeon)** under **Ecosystem**.

Aeon is an open-source autonomous agent framework that runs unattended on GitHub Actions. Its scheduled Markdown "skills" can hit x402-gated endpoints and settle USDC through Bankr agent wallets on Base, so agents make paid API calls and on-chain actions with no human in the loop — alongside Uniswap v4 hook deploys and on-chain monitoring.

Fits this list because it is an x402-consuming autonomous agent, grouped next to the existing agent infrastructure entries (AgentZone, AgentStatus, CardZero).

- Repo: https://github.com/aeonfun/aeon
- License: MIT · actively maintained

Grouped under the existing Ecosystem section per the contributing note, single bullet, formatting matches the surrounding lines.
