### PR TITLE
Add Edge Agents AI and T54 XRPL facilitator

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Edge Agents AI](https://edge-agents.ai) - Machine-purchasable crypto and macro market intelligence over x402, 20 services from $0.01, settling on Base mainnet (USDC) or XRPL mainnet (RLUSD) via T54's XRPL facilitator.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)
@@ -49,6 +50,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [thirdweb Facilitator & Supported Networks](https://portal.thirdweb.com/payments/x402/facilitator)
 - [Corbits Faremeter Facilitators & Supported Networks](https://docs.corbits.dev/about-corbits/networks)
 - [OpenZeppelin Relayer x402 Facilitator](https://docs.openzeppelin.com/relayer/guides/stellar-x402-facilitator-guide) - Stellar x402 facilitator plugin for payment verification and settlement via OpenZeppelin Relayer.
+- [T54 XRPL x402 Facilitator](https://xrpl-x402.t54.ai/) - XRPL mainnet x402 settlement facilitator: verifies and settles presigned XRPL Payment transactions, supporting native XRP and issued currencies such as RLUSD.
 
 
 ### Open Source & SDKs


### PR DESCRIPTION
Edge Agents AI is a live x402 market-intelligence provider: 801 paid routes priced from $0.01 with premium synthesis at $0.10 and flagship bundles at $0.25, settling in USDC on Base, Solana, Arbitrum and Polygon, or RLUSD on XRPL. The entry avoids a hard-coded service count and points discovery at the production OpenAPI, so later service additions do not make it stale. Canonical site: https://edge-agents.ai; API/discovery origin: https://pay.edge-agents.ai. The T54 XRPL facilitator addition in this PR is unchanged.