### PR TITLE
Add Animica x402 to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Animica x402](https://animica.dev/x402) - Pay-per-call catalogue of 72 agent APIs (chain reads and address history, randomness with signed digest attestations, classification, priority inference) settling in USDC on Base, plus an ANM-native lane. 44 of the 72 carry a free-trial endpoint that runs the same code as the paid one, so a client can evaluate before paying, and aggregate settlement counts are published at [/x402/stats](https://animica.dev/x402/stats). Apache-2.0; [MCP server](https://pypi.org/project/animica-mcp/) available.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds Animica x402 to the Ecosystem section.

Animica runs 47 x402 pay-per-request APIs for agents (web search/research/contents, structured extraction and classification, verifiable randomness, chain exports, a GEO/agent-legibility audit, OpenAI-compatible inference) and an agent-to-agent job network with escrow. Settlement is USDC on Base via a self-hosted facilitator, or natively in ANM at a 25% discount; every product has a free trial route and prepaid credits are available.

- Machine catalog: https://animica.dev/.well-known/x402
- OpenAPI (with `x-payment-info`): https://animica.dev/openapi.json
- Listed on x402scan, 402 Index and agent-tools.cloud.
