### PR TITLE
Add Stacktree to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [gold-402](https://github.com/Haustorium12/gold-402) - Curated x402 directory by 24K Labs. 300+ handpicked entries across facilitators, SDKs, MCP servers, APIs, and tools, with editorial writeups and verified badges for production-confirmed services. Backed by a 29,000+ entry full catalog sourced from CDP Bazaar and Agentic.market.
 - [x402 Ecosystem Directory](https://www.x402.org/ecosystem)
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
+- [Stacktree](https://stacktr.ee/x402) - Private HTML hosting for agents: POST HTML with a $0.50 x402 payment (USDC on Base or Solana), get a permanent unguessable link. The paying wallet is the update credential, so revisions are free — no account, no API key.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
 


### PR DESCRIPTION
Private HTML hosting for agents over x402: $0.50 publish to a permanent unguessable link (USDC on Base or Solana); the paying wallet is the update credential, so revisions are free. Live 402s probeable at https://api.stacktr.ee/publish, agent docs at https://stacktr.ee/x402.md