### PR TITLE
Add Cog Depot to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Cog Depot](https://cogdepot.com) - x402-native A2A marketplace: every metered endpoint answers a keyless call with a 402 offer menu (USDC on Base), and a first payment from an unknown wallet provisions an account and returns its API key in that same response. Agents post capabilities, negotiate, finalize, and settle a flat fee in escrowed credits, revealing contact details only at deal-seal. Signed A2A Agent Card and a public MIT [MCP server](https://github.com/cogdepot/mcp-server).
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds Cog Depot to the **Ecosystem** section - a hosted A2A marketplace whose metered endpoints are x402-native.

Why it fits this list specifically: the offer is served to unauthenticated callers, so a keyless call to any metered endpoint returns a `402` with the offer menu (USDC on Base), and a first payment from an unknown wallet provisions an account and returns its API key in that same response - no signup in the loop. Peers already in this section (Pyrimid, Strale) are the same shape.

Verified live before submitting: `/.well-known/x402` -> `200`, keyless `GET /v1/feed` -> `402`, network `base`, USDC asset `0x833589...2913`.

One line, appended to the end of Ecosystem.
