### PR TITLE
Add get4agent (Ecosystem) and regent-httpsig (Open Source & SDKs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [get4agent](https://get4agent.com) - Trust-layer marketplace for agent commerce: KYC-verified sellers, budget-capped agent buyers, per-call billing with x402 support, on-chain audit anchoring. Agents self-register by RFC 9421 signature; every priced call is gated by an owner-set mandate before money moves.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)
@@ -92,6 +93,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Routeweiler](https://github.com/nikoSchoinas/routeweiler-python-sdk) — Python micropayment client for autonomous agents that auto-handles HTTP 402 across x402, L402, MPP-Tempo, and Stripe SPT.
 - [agentpay-mcp](https://github.com/up2itnow0822/agentpay-mcp) ([npm](https://www.npmjs.com/package/agentpay-mcp)) - Non-custodial x402 MCP payment server for AI agents. Local signing — no custodial infrastructure. x402 V2 session payments, Base USDC, CCTP cross-chain.
 - [PipRail](https://github.com/piprail/piprail) - Backendless, MIT TypeScript SDK for x402 across 28 chains in 10 families (EVM, Solana, TON, Tron, NEAR, Sui, Aptos, Algorand, Stellar, XRPL). No facilitator, no fee — payments settle straight to your wallet, verified locally against your own RPC. ([npm](https://www.npmjs.com/package/@piprail/sdk))
+- [regent-httpsig](https://github.com/regent-protocol/regent-httpsig) - Open-source Python verifier/signer for agent HTTP traffic: RFC 9421 HTTP Message Signatures, Web Bot Auth, and AAuth (incl. the budgets draft) — the identity layer for deciding which agent is paying before an x402 charge. ([PyPI](https://pypi.org/project/regent-httpsig/))
 
 ### Standards and EIPs
 - [HTTP 402 Payment Required (MDN)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/402): browser-facing reference for the status code x402 standardizes around.


### PR DESCRIPTION
Two entries, grouped under existing sections per the contributing guidelines:

**Ecosystem — [get4agent](https://get4agent.com):** trust-layer marketplace for agent commerce. KYC-verified sellers, budget-capped agent buyers, per-call billing with x402 support, on-chain audit anchoring. Agents self-register by RFC 9421 signature and every priced call passes an owner-set mandate gate before money moves.

**Open Source & SDKs — [regent-httpsig](https://github.com/regent-protocol/regent-httpsig):** Python verifier/signer for agent HTTP traffic — RFC 9421 HTTP Message Signatures, Web Bot Auth, and AAuth including the budgets draft. Adjacent standard to x402 flows: it answers which agent is paying before the charge. On [PyPI](https://pypi.org/project/regent-httpsig/).

Both run in production.