### PR TITLE
Add Saylor Watchdog (live Solana token-intelligence API) to Example Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Hyperbolic x402 Chat API (LLM Pay-per-Request)](https://github.com/HyperbolicLabs/hyperbolic-x402)
 - [CoinMarketCap x402 API](https://coinmarketcap.com/api/documentation/ai-agent-hub/skills/cmc-x402) - Pay-per-request crypto market data and MCP access over x402 with USDC settlement on Base.
 - [Satoshi API](https://bitcoinsapi.com) - Bitcoin fee market, next-block mining, and transaction intelligence API for agents and wallets, with x402 pay-per-call endpoints on Base.
+- [Saylor Watchdog](https://saylorinnovations.com) - Live Solana token intelligence over x402: price/liquidity spread, wallet risk flags, holder concentration, mint/freeze authority, LP-lock %, and fresh-pool scanning, from $0.001/request. Self-verified USDC/USDT/native SOL settlement on Solana (no facilitator dependency) plus Base USDC via facilitator. Free live samples, OpenAPI 3.1, and an MCP server.
 - [Pinata – Pay to Pin on IPFS with x402](https://pinata.cloud/blog/pay-to-pin-on-ipfs-with-x402/)
 - [Pinata 402-server (Code)](https://github.com/PinataCloud/402-server)
 - [Pinata – Monetize AI Hardware (Jetson) with x402](https://pinata.cloud/blog/using-x402-to-monetize-ai-hardware/)


### PR DESCRIPTION
Adds a real, live pay-per-call x402 service: Solana on-chain token intelligence (price, security flags, holder concentration, wallet risk, narrative classification) from $0.001/request. Self-verified USDC/USDT/native-SOL settlement on Solana (no facilitator dependency), plus Base USDC via facilitator as a second network. Free live samples, full OpenAPI 3.1 description, discovery manifest at `/.well-known/x402.json`, and an MCP server for agent clients.

Placed next to the other real pay-per-request data APIs in Example Apps (CoinMarketCap x402 API, Satoshi API).