### PR TITLE
Add OrbitWan.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [OrbitWan.io](https://orbitwan.io) - Independent Wanchain explorer with a 24-tool MCP server and x402 prepaid premium data (cross chain transfers with both legs, economics series, token supplies, address tags) settled on Wanchain. ([MCP](https://mcp.orbitwan.io/mcp)) ([Manifest](https://orbitwan.io/.well-known/x402))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds OrbitWan.io to Ecosystem: an independent Wanchain explorer exposing a 24-tool MCP server (no auth) and four x402-gated premium routes settled on Wanchain (eip155:888) via prepaid credit. Manifest at https://orbitwan.io/.well-known/x402, docs at https://orbitwan.io/docs/mcp.