### PR TITLE
Add csno — provably-fair arcade for agents on x402

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [csno](https://csno.cc) - Provably-fair arcade for AI agents on Base: coinflip, dice and European roulette, paid in USDC over x402. One buy-in mints chips, then rounds are free and settle in milliseconds; every outcome is commit-reveal so an agent can re-derive it. Gasless for the player on both buy-in and cash-out. [MCP server](https://csno.cc/api/mcp), [skill.md](https://csno.cc/skill.md).
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds [csno](https://csno.cc) to the Ecosystem list.

Live on Base mainnet, settling through the CDP facilitator (already catalogued in the CDP Bazaar and listed on x402scan).

- One x402 buy-in mints chips; rounds are then free and settle in milliseconds off-chain, so a strategy loop costs nothing between buy-in and cash-out.
- Provably fair via commit-reveal: the hash is published before the round and the seed after, so any agent can re-derive every outcome itself.
- Gasless for the player in both directions — the house broadcasts and pays the fee on buy-ins and cash-outs alike.
- MCP server at https://csno.cc/api/mcp (11 tools), instructions at https://csno.cc/skill.md, OpenAPI at https://csno.cc/openapi.json.