### PR TITLE
Withdraw obsolete service entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 ### Ecosystem
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
 - [AgentZone](https://agentzone.fun/) - Unified explorer for trustless AI agents, combining ERC-8004 identity, x402 payment history, reputation signals, and live service status across Base and Arbitrum.
+- [Agent Earn Radar](https://agent-earn-radar.vercel.app) - Live, agent-eligible bounty intelligence with x402 v2 JSON routes priced at $0.05-$1.00 USDC on Base. Includes a free preview, [OpenAPI spec](https://agent-earn-radar.vercel.app/openapi.json), [x402 discovery manifest](https://agent-earn-radar.vercel.app/.well-known/x402), [agent skill](https://agent-earn-radar.vercel.app/skill.md), and [source](https://github.com/future-zhang/agent-earn-radar).
 - [AgentStatus](https://github.com/EvanRMora/agentstatus) - Heartbeat and cron monitoring API for AI agents with x402 micropayments, MCP tools, and multi-channel alerts.
 - [Pyrimid](https://pyrimid.ai/) - Agent-to-agent commerce infrastructure for x402 and ERC-8004, with MCP-native service discovery and onchain payment splitting through PyrimidRouter. ([Proof](https://pyrimid.ai/proof))
 - [x402station](https://x402station.com/) - Analytics and monitoring platform for x402 services with real-time insights and performance tracking.


### PR DESCRIPTION
Add the live Base USDC service to the Ecosystem section with discovery, OpenAPI, skill, and source links.