### PR TITLE
Add Citable to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Citable](https://citable.run) - SEO and AI-visibility data agents buy per call: keyword research, on-page audits, AI-citation checks across ChatGPT, Claude, Gemini and Perplexity, plus rank, SERP, domain and backlink data. 17 endpoints at $0.005–0.30 in USDC on Solana, no account or API key, and a failed call is never charged. ([MCP server](https://www.npmjs.com/package/citable-mcp), [OpenAPI](https://citable.run/openapi.json), [x402scan](https://www.x402scan.com/server/2c5be88d-dc11-4463-afad-5c415c302d6f))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds **Citable** under Ecosystem — a live x402 service on Solana mainnet.

SEO and AI-visibility data agents buy per call: keyword research, on-page audits, AI-citation checks across ChatGPT, Claude, Gemini and Perplexity, plus rank, SERP, domain and backlink data. 17 endpoints at $0.005–0.30 in USDC on Solana, no account or API key, and a failed call is never charged (any 4xx/5xx cancels the payment instead of settling it).

Verifiable:
- Discovery: https://citable.run/openapi.json (`x-payment-info` per route) and https://citable.run/.well-known/x402
- Indexed on x402scan with all 17 resources: https://www.x402scan.com/server/2c5be88d-dc11-4463-afad-5c415c302d6f
- MCP server: https://www.npmjs.com/package/citable-mcp, listed in the official MCP registry as `io.github.zaialamm/citable-mcp`
- Facilitator: PayAI

One line added under an existing section.