### PR TITLE
Add Sourcey Startup Review

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Sourcey Startup Review](https://api.sourcey.com/v1/startup-credits/reviews) - x402 v2 endpoint for evidence-backed human review of startup credit and startup program submissions. Costs $25 USDC on Base; payment funds review and never guarantees Catalog publication. ([Discovery](https://api.sourcey.com/.well-known/x402)) ([OpenAPI](https://api.sourcey.com/openapi.yml)) ([MCP](https://mcp.sourcey.com/mcp))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds Sourcey Startup Review as a live x402 v2 service in the ecosystem section.

- Direct resource: `https://api.sourcey.com/v1/startup-credits/reviews`
- Discovery: `https://api.sourcey.com/.well-known/x402`
- OpenAPI: `https://api.sourcey.com/openapi.yml`
- 25 USDC on Base; review is funded, publication is never purchased.
