### PR TITLE
Add 402Signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402charity](https://x402charity.com) — Open-source micro-donation server. Triggers USDC charity donations on every HTTP event via x402. Express/Next.js middleware, CLI, Vercel-ready. ([GitHub](https://github.com/allscale-io/x402charity)) ([npm](https://www.npmjs.com/package/x402charity))
 
 ### Example Apps
+- [402Signal](https://402signal.com) - Fail-closed live-endpoint x402 router. POST `/route` returns a currently-alive x402 URL or an honest miss. $0.01 USDC on Base, Solana, and Algorand. MCP: https://402signal.com/mcp. OpenAPI: https://402signal.com/openapi.json.
 - [QuickNode Video Paywall Demo](https://www.quicknode.com/sample-app-library/coinbase-x402)
 - [Hyperbolic x402 Chat API (LLM Pay-per-Request)](https://github.com/HyperbolicLabs/hyperbolic-x402)
 - [CoinMarketCap x402 API](https://coinmarketcap.com/api/documentation/ai-agent-hub/skills/cmc-x402) - Pay-per-request crypto market data and MCP access over x402 with USDC settlement on Base.


### PR DESCRIPTION
Add [402Signal](https://402signal.com) under Example Apps.

Fail-closed live-endpoint x402 router: agents POST `/route` with a plain-English need. Unpaid calls return HTTP 402. After $0.01 USDC on Base, Solana, or Algorand, the server returns a currently-alive x402 URL or an honest miss.

- Live: https://402signal.com
- Paid: POST https://402signal.com/route
- OpenAPI: https://402signal.com/openapi.json
- MCP: https://402signal.com/mcp
- Contact: 402signal@gmail.com