### PR TITLE
Add ScrapeCheck to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [ScrapeCheck](https://scrapecheck.fly.dev) - You send us a URL and the value you believe is on that page. We re-fetch it independently and return a signed pass, fail, or unverifiable. Never a guess. ([MCP](https://github.com/FieldmodeLLC/scrapecheck-mcp))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds ScrapeCheck (scrapecheck.fly.dev), an independent web-data verification service paid over x402: an agent sends a URL and the value it believes is on that page; we re-fetch independently and return an ed25519-signed pass, fail, or unverifiable verdict that verifies offline. Entry follows the section's one-line format. Happy to adjust wording or placement to your conventions.