### PR TITLE
Add ProfitCollector to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [ProfitCollector](https://api.bakhour.ca) - Machine-payable (x402/USDC on Base) repository security due-diligence: dependency vulnerability scan, secret detection, and OpenSSF Scorecard-based maintainer/governance signals, in three depth tiers (`$20`/`$50`/`$100`). Also a `$5` x402 service trust report that checks an unfamiliar x402 seller's payment structure, TLS, and on-chain payTo balance before you pay them. MCP server included.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds ProfitCollector (https://api.bakhour.ca) to the Ecosystem section: a machine-payable (x402/USDC on Base) repository security due-diligence service — dependency vulnerability scan, secret detection, and OpenSSF Scorecard-based maintainer/governance signals in three depth tiers, plus a $5 x402 service trust report for checking an unfamiliar seller's payment structure/TLS/on-chain balance before paying. MCP server included.

One line added, matching the existing entry format (e.g. Strale, CardZero). No other changes.