### PR TITLE
Add OpenZoo to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
 
+- [OpenZoo](https://openzoo.fun) - OpenAI-compatible LLM inference with no API key; per-request x402 settlement on Solana and Base, with a local `npx openzoo` gateway that pays automatically.
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)
 - [Supported Networks](https://docs.cdp.coinbase.com/get-started/supported-networks#x402)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
 
-- [OpenZoo](https://openzoo.fun) - OpenAI-compatible LLM inference with no API key; per-request x402 settlement on Solana and Base, with a local `npx openzoo` gateway that pays automatically.
+- [OpenZoo](https://openzoo.fun) - Local x402-paying proxy (`npx openzoo`) + OpenAI-compatible endpoint for LLM inference: no account, no API key; pays per call in USDC on Solana or Base from a local burner wallet. The hosted gateway answers 402 unless the caller pays x402 or presents an OpenZoo subscription key.
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)
 - [Supported Networks](https://docs.cdp.coinbase.com/get-started/supported-networks#x402)


### PR DESCRIPTION
Adds [OpenZoo](https://openzoo.fun): a local x402-paying proxy (`npx openzoo`) + OpenAI-compatible endpoint for LLM inference — no account, no API key; each call is paid per request via x402 in USDC on Solana or Base from a local burner wallet. The hosted gateway (`https://api.openzoo.fun/v1`) answers 402 unless the caller pays x402 or presents an OpenZoo subscription key. Discovery: https://api.openzoo.fun/.well-known/x402.json. Disclosure: I operate OpenZoo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
