### PR TITLE
Add Hype-Signal API to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Hype-Signal API](https://hype.fortknoxx.pro) - Social-hype spike detection for AI trading agents. Sudden StockTwits message-volume spikes on trending US tickers, age-tagged EARLY/MID/LATE (hype lags price, so the tag flags early vs already-run). Keyless USDC on Base via the xpay facilitator (no API key/account/CDP); `/hype/spikes` $0.01, `/hype/{ticker}` $0.05. ([Discovery](https://hype.fortknoxx.pro/.well-known/x402))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds **Hype-Signal API** ([hype.fortknoxx.pro](https://hype.fortknoxx.pro)) to the Ecosystem list.

A live x402 service for AI trading agents: a derived social-hype signal — sudden StockTwits message-volume spikes on trending US tickers, age-tagged EARLY/MID/LATE (hype lags price, so the tag flags whether a move is early or already run).

- `/hype/spikes` $0.01 USDC · `/hype/{ticker}` $0.05 USDC
- Keyless USDC on **Base mainnet** via the **xpay** facilitator (no API key/account/CDP), x402 v2
- Discovery: https://hype.fortknoxx.pro/.well-known/x402

Thanks for curating this list!