### PR TITLE
Add Excelexi to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Excelexi](https://excelexi.com) - Pay-per-call technical-indicator and market-analysis API for trading agents: 73 indicators and 24 derived signals across 100 crypto markets, screening, and a natural-language query endpoint that compiles to a deterministic IR before executing. Every value returns with provenance (bars used, warm-up satisfied, staleness, source). $0.00002-$0.0005 USDC on Base via x402 v2, keyless. ([OpenAPI](https://api.excelexi.com/openapi.json))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds Excelexi to **Ecosystem**, alongside the other x402-payable services listed there.

A pay-per-call technical-indicator and market-analysis API for trading agents: 73 indicators and 24 derived signals across 100 crypto markets, plus screening, analytics, and a natural-language query endpoint.

**Verifiable now:**

- 402 challenge: `GET https://api.excelexi.com/api/v1/technical-analysis?symbol=BTCUSDT`
- Manifest: https://api.excelexi.com/.well-known/x402
- OpenAPI: https://api.excelexi.com/openapi.json

USDC on Base mainnet, x402 v2 (EIP-3009), keyless — 9 payable endpoints at $0.00002–$0.0005 per call.

Two design choices that may be of interest given this list's focus: every returned value carries a provenance block (which bars fed the calculation, whether the warm-up period was satisfied, staleness, upstream source), and on the natural-language endpoint the model never emits numbers — the query compiles to a deterministic IR that the engine executes and the model only narrates, so re-running a question returns byte-identical values.

Excelexi is already listed on x402scan (registered 2026-08-11, 67 resources / 9 paid endpoints).

Output is informational only and not financial advice.