### PR TITLE
Add Ausca (metered agent infrastructure over x402)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Ausca](https://ausca.com) - Metered agent infrastructure services (document OCR, document analysis, media transcription, browser sessions, agent inboxes) paid per call in USDC on Base over x402 v2, with no account or API keys and a settlement receipt on every completed invocation. Clients on npm and PyPI (`ausca`) include a local wallet-holding MCP server under a hard per-call USD cap. ([Discovery](https://ausca.com/.well-known/x402) | [MCP](https://ausca.com/mcp))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds Ausca to the x402 section.

Metered agent infrastructure services (document OCR, document analysis, media transcription, browser sessions, agent inboxes) paid per call in USDC on Base over x402 v2. No account or API keys; every completed invocation carries a settlement receipt. Buyer clients on npm and PyPI include a local wallet-holding MCP server with a hard per-call USD cap. Discovery: https://ausca.com/.well-known/x402