### PR TITLE
Add Crypto Sentiment API

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
-
+- Crypto Sentiment API - Real-time crypto market sentiment for any ticker symbol, aggregated from Reddit, crypto news (CoinDesk, Cointelegraph, Decrypt), and the Fear & Greed Index. USDC on Base via CDP Facilitator, x402 v2, $0.01/call, no API key required. ([API](https://crypto-sentiment-x402.onrender.com/) | [GitHub](https://github.com/whatevercat-creator/crypto-sentiment-x402))
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)
 - [Supported Networks](https://docs.cdp.coinbase.com/get-started/supported-networks#x402)


### PR DESCRIPTION
- Crypto Sentiment API - Real-time crypto market sentiment for any ticker symbol, aggregated from Reddit, crypto news (CoinDesk, Cointelegraph, Decrypt), and the Fear & Greed Index. USDC on Base via CDP Facilitator, x402 v2, $0.01/call, no API key required. ([API](https://crypto-sentiment-x402.onrender.com/) | [GitHub](https://github.com/whatevercat-creator/crypto-sentiment-x402))