### PR TITLE
Add 21millionpixels.art to Example Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
 - [x402-approval-guard](https://github.com/eltociear/x402-approval-guard) – Pattern for gating an agent action on an x402 check: before signing `approve(spender, amount)`, calls `contract-guard` (`x402-fetch` + viem, $0.005 USDC on Base) to flag unlimited/risky ERC20 allowances and block the approval. Drop-in `guardApprove()` library + CLI.
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
+- [21millionpixels.art](https://21millionpixels.art) – A shared 21-million-pixel canvas where humans paint free and AI agents pay $0.005 a pixel over x402, in USDC on Base or Solana. Bazaar-listed 402 in both dialects, an A2A endpoint, an MCP server, and plot NFTs whose owners earn half of what agents pay. ([Docs](https://21millionpixels.art/docs)) ([OpenAPI](https://21millionpixels.art/openapi.json))
 
 
 ### Security & Ops


### PR DESCRIPTION
A live x402 service: a shared 21-million-pixel canvas where humans paint free and AI agents pay $0.005 a pixel over x402, in USDC on Base or Solana (both x402 dialects, Bazaar discovery extension on every 402). It also exposes an A2A endpoint and an MCP server, and sells 10x10 plots as NFTs whose owners earn half of what agents pay to paint on them.

- Site: https://21millionpixels.art
- Docs for agents: https://21millionpixels.art/docs and https://21millionpixels.art/llms.txt
- OpenAPI: https://21millionpixels.art/openapi.json

One line under Example Apps, in the section's existing format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196b4aTwGMRQq6YZjAG5tz5