### PR TITLE
Add Deploid Enrich work-email enrichment pilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [gold-402](https://github.com/Haustorium12/gold-402) - Curated x402 directory by 24K Labs. 300+ handpicked entries across facilitators, SDKs, MCP servers, APIs, and tools, with editorial writeups and verified badges for production-confirmed services. Backed by a 29,000+ entry full catalog sourced from CDP Bazaar and Agentic.market.
 - [x402 Ecosystem Directory](https://www.x402.org/ecosystem)
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
+- [Deploid Enrich](https://enrich.deploid.now) - Work-email enrichment for AI agents via x402 v2 on Base. Limited public pilot; 0.15 USDC per FullEnrich DELIVERABLE work email, asynchronous jobs and free polling. No match, no charge. [Integration guide](https://enrich.deploid.now/integrate).
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
 


### PR DESCRIPTION
# Add Deploid Enrich work-email enrichment API

Adds Deploid Enrich to the existing x402 service/project section.

Affiliation: submitted on behalf of Deploid.now, the service operator.

Deploid Enrich is a **limited public pilot**, not a general-availability or unlimited service. It provides one FullEnrich-classified DELIVERABLE work email for a known professional, paid through x402 v2 using native USDC on Base. The price is 0.15 USDC per eligible result. The API returns asynchronous jobs, polling is free, and no-match or rejected-quality outcomes do not initiate settlement. A pending payment is not a confirmed free result. The buyer needs a compatible funded wallet signer; no merchant signup or merchant API key is required.

Useful links:

- Website: https://enrich.deploid.now
- Integration and safe retry guide: https://enrich.deploid.now/integrate
- OpenAPI: https://enrich.deploid.now/openapi.json
- Discovery: https://enrich.deploid.now/.well-known/x402
- Advisory readiness: https://enrich.deploid.now/ready

Verification: an unsigned POST to `https://enrich.deploid.now/v1/work-email` returns an x402 v2 HTTP 402 quote for 150000 micro-USDC on `eip155:8453`, without initiating a lookup or payment. The live documentation covers inputs, authorization, persisted retries, asynchronous job polling, payment uncertainty and retention. The service excludes personal-email discovery, phone lookup and automated outreach. Supplier verification is not consent to contact or a guarantee of inbox delivery.

This is a documentation-only listing request. It does not claim independent customer traction, endorsement, a hosted MCP server, multiple production chains, or guaranteed performance. Listing remains subject to maintainer review.
