### PR TITLE
Add aiworker-data (x402 seller: DeFi data, page Markdown, remote MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [aiworker-data](https://aiworker.duckdns.org/) - Pay-per-call DeFi data (DefiLlama yields and protocol snapshots) and public-page Markdown/summary endpoints for agents, $0.01–$0.04 USDC per call over x402 on Base and Solana; the same four tools are served as a remote MCP at `/mcp`. ([OpenAPI](https://aiworker.duckdns.org/openapi.json))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds **aiworker-data** under Ecosystem: a live x402 v2 seller (four pay-per-call endpoints — DefiLlama yields and protocol snapshots, public-page Markdown and LLM summaries — $0.01–$0.04 USDC on Base and Solana via PayAI), also exposed as a remote MCP at `/mcp` and listed in the official MCP Registry as `org.duckdns.aiworker/aiworker-data`.

- OpenAPI with `x-payment-info` on every paid operation: https://aiworker.duckdns.org/openapi.json
- A bare `GET https://aiworker.duckdns.org/v1/defi/protocol/aave-v3` answers a 402 with `PAYMENT-REQUIRED`.
- Registered on x402scan and x402 Arena.
