### PR TITLE
Add Gardenpatch Growth Coaches (x402 pay-per-call API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
 - [x402-approval-guard](https://github.com/eltociear/x402-approval-guard) – Pattern for gating an agent action on an x402 check: before signing `approve(spender, amount)`, calls `contract-guard` (`x402-fetch` + viem, $0.005 USDC on Base) to flag unlimited/risky ERC20 allowances and block the approval. Drop-in `guardApprove()` library + CLI.
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
+- [Gardenpatch Growth Coaches](https://gardenpatch.xyz/docs/agents) - Seven pay-per-call growth coaches over x402 (USDC on Base, $0.18 to $0.45 per call): unpaid POST returns a 402 with the Bazaar extension, paid retry returns a typed JSON deliverable. Free catalog at /api/v1/agents, OpenAPI, and an agent SKILL.md.
 
 
 ### Security & Ops


### PR DESCRIPTION
Adds one entry to Example Apps: Gardenpatch Growth Coaches, seven x402 pay-per-call growth coaches on Base (USDC, $0.18 to $0.45 per call).

Live surfaces: discovery at https://gardenpatch.xyz/.well-known/x402, free catalog at https://gardenpatch.xyz/api/v1/agents, OpenAPI at https://gardenpatch.xyz/openapi.json, docs at https://gardenpatch.xyz/docs/agents. An unpaid POST to any coach returns a 402 carrying x402 v2 requirements plus the Bazaar extension; CDP's validate endpoint returns simulation.outcome accepted for all seven routes.