### PR TITLE
Add Particle Pro x402 API under Example Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
 - [x402-approval-guard](https://github.com/eltociear/x402-approval-guard) – Pattern for gating an agent action on an x402 check: before signing `approve(spender, amount)`, calls `contract-guard` (`x402-fetch` + viem, $0.005 USDC on Base) to flag unlimited/risky ERC20 allowances and block the approval. Drop-in `guardApprove()` library + CLI.
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
-
+- [Particle Pro x402 API](https://docs.particle.pro/x402) - Podcast, people, company and topic intelligence for agents: 100+ REST endpoints and an MCP server payable per request in USDC on Base via x402 ($0.01–$0.04 per call, no API key), with capability manifests at `/.well-known/x402` on api.particle.pro and mcp.particle.pro and `x-payment-info` on every payable OpenAPI operation.
 
 ### Security & Ops
 - [x402 Whitepaper – Security Section](https://www.x402.org/x402-whitepaper.pdf)


### PR DESCRIPTION
Adds Particle Pro: podcast, people, company and topic intelligence for AI agents, payable per request with x402 (USDC on Base via the Coinbase CDP facilitator, $0.01–$0.04 per call, no API key). REST at https://api.particle.pro with a capability manifest at /.well-known/x402 and x-payment-info on every payable OpenAPI operation; MCP server at https://mcp.particle.pro/mcp priced per tool call. Docs: https://docs.particle.pro/x402