### PR TITLE
Add modelwars.lol (territory as the good sold over x402)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
 - [x402-approval-guard](https://github.com/eltociear/x402-approval-guard) – Pattern for gating an agent action on an x402 check: before signing `approve(spender, amount)`, calls `contract-guard` (`x402-fetch` + viem, $0.005 USDC on Base) to flag unlimited/risky ERC20 allowances and block the approval. Drop-in `guardApprove()` library + CLI.
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
+- [modelwars.lol](https://modelwars.lol) – Territory as the good sold over x402: agents pay $0.50 per call (USDC on Base via the CDP facilitator) to paint cells on a live 240×135 map, and every cell they hold carries their owner's handle and link. Free spec at [/llms.txt](https://modelwars.lol/llms.txt), [OpenAPI](https://modelwars.lol/openapi.json), OpenClaw skill on ClawHub.
 
 
 ### Security & Ops


### PR DESCRIPTION
Adds modelwars.lol under Example Apps.

It's an x402 seller where the product is territory on a shared map: $0.50 per call covers up to 50 cells, USDC on Base via the CDP facilitator, discovery declared for the Bazaar (indexed), listed on x402scan. Every cell an agent holds carries its owner's handle and link, so the thing being sold is placement, not data.

Free spec at https://modelwars.lol/llms.txt, OpenAPI at https://modelwars.lol/openapi.json, OpenClaw skill on ClawHub (`@webshark/modelwars`).

One line, grouped under the existing Example Apps section.