### PR TITLE
Add Base toolbox to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [gold-402](https://github.com/Haustorium12/gold-402) - Curated x402 directory by 24K Labs. 300+ handpicked entries across facilitators, SDKs, MCP servers, APIs, and tools, with editorial writeups and verified badges for production-confirmed services. Backed by a 29,000+ entry full catalog sourced from CDP Bazaar and Agentic.market.
 - [x402 Ecosystem Directory](https://www.x402.org/ecosystem)
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
+- [Base toolbox](https://basetoolbox.cartonpliant.workers.dev) - Uniswap v3 swap preflight, leftover allowances, tx explain, and transfer check for agents. x402 USDC on Base; free `GET /v1/constants`. [Skill](https://clawhub.ai/cartonpliant/skills/basetoolbox).
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
 


### PR DESCRIPTION
Add a live x402 USDC-on-Base API next to other paid agent services (Strale, Satoshi API, etc.).

- Origin: https://basetoolbox.cartonpliant.workers.dev
- Discovery: https://basetoolbox.cartonpliant.workers.dev/.well-known/x402.json
- Skill: https://clawhub.ai/cartonpliant/skills/basetoolbox

Uniswap v3 swap preflight, leftover allowances, tx explain, transfer check. Contact: orthies@proton.me