### PR TITLE
Add Hyperliquid Liquidation Risk Index to Example Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Hyperbolic x402 Chat API (LLM Pay-per-Request)](https://github.com/HyperbolicLabs/hyperbolic-x402)
 - [CoinMarketCap x402 API](https://coinmarketcap.com/api/documentation/ai-agent-hub/skills/cmc-x402) - Pay-per-request crypto market data and MCP access over x402 with USDC settlement on Base.
 - [Satoshi API](https://bitcoinsapi.com) - Bitcoin fee market, next-block mining, and transaction intelligence API for agents and wallets, with x402 pay-per-call endpoints on Base.
+- [Hyperliquid Liquidation Risk Index](https://hlrisk.paidapis.net) - Real-time Hyperliquid BTC/ETH perpetual futures liquidation risk index (notional at risk, closest-to-liquidation position, funding rate) built from live on-chain position data, pay-per-call in USDC on Base via x402.
 - [Pinata – Pay to Pin on IPFS with x402](https://pinata.cloud/blog/pay-to-pin-on-ipfs-with-x402/)
 - [Pinata 402-server (Code)](https://github.com/PinataCloud/402-server)
 - [Pinata – Monetize AI Hardware (Jetson) with x402](https://pinata.cloud/blog/using-x402-to-monetize-ai-hardware/)


### PR DESCRIPTION
Adds a pay-per-call x402 API under Example Apps: real-time Hyperliquid BTC/ETH perpetual futures liquidation risk data (notional at risk if price moves ±1%/3%/5%, position closest to liquidation, funding rate), built from live on-chain position data rather than a statistical estimate. USDC on Base, no signup or API key required.