### PR TITLE
Add ASIC Company Lookup to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [ASIC Company Lookup](https://api.nightshiftbuilds.com) - Australian company register lookups by ABN, ACN or name over the ASIC Company Dataset (4,008,800 entities). USD 0.01 per call in USDC on Base, no account or API key, with OpenAPI, llms.txt and a bazaar discovery extension. [Docs and examples](https://github.com/keitaemsden-lab/asic-lookup-api-docs).
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds an x402-paid Australian company register API to the Ecosystem section. Live, settling on Base through the PayAI facilitator, with public docs and runnable examples at https://github.com/keitaemsden-lab/asic-lookup-api-docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gnbj5TFnS1KnQwPu9UuUg8