### PR TITLE
Add x402 Toolbox to Example Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [QuickNode Video Paywall Demo](https://www.quicknode.com/sample-app-library/coinbase-x402)
 - [Hyperbolic x402 Chat API (LLM Pay-per-Request)](https://github.com/HyperbolicLabs/hyperbolic-x402)
 - [CoinMarketCap x402 API](https://coinmarketcap.com/api/documentation/ai-agent-hub/skills/cmc-x402) - Pay-per-request crypto market data and MCP access over x402 with USDC settlement on Base.
-- [Satoshi API](https://bitcoinsapi.com) - Bitcoin fee market, next-block mining, and transaction intelligence API for agents and wallets, with x402 pay-per-call endpoints on Base.- [x402-experiments](https://lab.paidapis.net) - 21 small real pay-per-call x402 endpoints on Base USDC, each demonstrating a distinct payment mechanic: oracle, multi-source oracle, escrow, task-runner, batch task-runner, prediction market, verified auction, insured data feed, reputation, alerting, and more. Educational project — every endpoint independently on-chain verifiable.
+- [Satoshi API](https://bitcoinsapi.com) - Bitcoin fee market, next-block mining, and transaction intelligence API for agents and wallets, with x402 pay-per-call endpoints on Base.
+- [x402-experiments](https://lab.paidapis.net) - 21 small real pay-per-call x402 endpoints on Base USDC, each demonstrating a distinct payment mechanic: oracle, multi-source oracle, escrow, task-runner, batch task-runner, prediction market, verified auction, insured data feed, reputation, alerting, and more. Educational project — every endpoint independently on-chain verifiable.
 - [Pinata – Pay to Pin on IPFS with x402](https://pinata.cloud/blog/pay-to-pin-on-ipfs-with-x402/)
 - [Pinata 402-server (Code)](https://github.com/PinataCloud/402-server)
 - [Pinata – Monetize AI Hardware (Jetson) with x402](https://pinata.cloud/blog/using-x402-to-monetize-ai-hardware/)

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [QuickNode Video Paywall Demo](https://www.quicknode.com/sample-app-library/coinbase-x402)
 - [Hyperbolic x402 Chat API (LLM Pay-per-Request)](https://github.com/HyperbolicLabs/hyperbolic-x402)
 - [CoinMarketCap x402 API](https://coinmarketcap.com/api/documentation/ai-agent-hub/skills/cmc-x402) - Pay-per-request crypto market data and MCP access over x402 with USDC settlement on Base.
-- [Satoshi API](https://bitcoinsapi.com) - Bitcoin fee market, next-block mining, and transaction intelligence API for agents and wallets, with x402 pay-per-call endpoints on Base.
+- [Satoshi API](https://bitcoinsapi.com) - Bitcoin fee market, next-block mining, and transaction intelligence API for agents and wallets, with x402 pay-per-call endpoints on Base.- [x402-experiments](https://lab.paidapis.net) - 21 small real pay-per-call x402 endpoints on Base USDC, each demonstrating a distinct payment mechanic: oracle, multi-source oracle, escrow, task-runner, batch task-runner, prediction market, verified auction, insured data feed, reputation, alerting, and more. Educational project — every endpoint independently on-chain verifiable.
 - [Pinata – Pay to Pin on IPFS with x402](https://pinata.cloud/blog/pay-to-pin-on-ipfs-with-x402/)
 - [Pinata 402-server (Code)](https://github.com/PinataCloud/402-server)
 - [Pinata – Monetize AI Hardware (Jetson) with x402](https://pinata.cloud/blog/using-x402-to-monetize-ai-hardware/)

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Hyperbolic x402 Chat API (LLM Pay-per-Request)](https://github.com/HyperbolicLabs/hyperbolic-x402)
 - [CoinMarketCap x402 API](https://coinmarketcap.com/api/documentation/ai-agent-hub/skills/cmc-x402) - Pay-per-request crypto market data and MCP access over x402 with USDC settlement on Base.
 - [Satoshi API](https://bitcoinsapi.com) - Bitcoin fee market, next-block mining, and transaction intelligence API for agents and wallets, with x402 pay-per-call endpoints on Base.
-- [x402-experiments](https://lab.paidapis.net) - 21 small real pay-per-call x402 endpoints on Base USDC, each demonstrating a distinct payment mechanic: oracle, multi-source oracle, escrow, task-runner, batch task-runner, prediction market, verified auction, insured data feed, reputation, alerting, and more. Educational project — every endpoint independently on-chain verifiable.
+- [x402 Toolbox](https://lab.paidapis.net) - 21 small real pay-per-call x402 endpoints on Base USDC, each demonstrating a distinct payment mechanic: oracle, multi-source oracle, escrow, task-runner, batch task-runner, prediction market, verified auction, insured data feed, reputation, alerting, and more. Every endpoint independently on-chain verifiable.
 - [Pinata – Pay to Pin on IPFS with x402](https://pinata.cloud/blog/pay-to-pin-on-ipfs-with-x402/)
 - [Pinata 402-server (Code)](https://github.com/PinataCloud/402-server)
 - [Pinata – Monetize AI Hardware (Jetson) with x402](https://pinata.cloud/blog/using-x402-to-monetize-ai-hardware/)


### PR DESCRIPTION
Adds x402 Toolbox under Example Apps: 21 real pay-per-call endpoints on Base mainnet USDC (no testnet, no simulated payments), each demonstrating a distinct payment mechanic — oracle, multi-source oracle, escrow-lite, task-runner, batch task-runner, verified auction, prediction market, insured data feed, reputation layer, alerting, and more. Every endpoint is independently on-chain verifiable.